### PR TITLE
Switch theme on android to default/light.

### DIFF
--- a/src/android/am/armsoft/plugins/ListPicker.java
+++ b/src/android/am/armsoft/plugins/ListPicker.java
@@ -73,7 +73,7 @@ public class ListPicker extends CordovaPlugin {
         // Create and show the alert dialog
         Runnable runnable = new Runnable() {
             public void run() {
-                AlertDialog.Builder builder = new AlertDialog.Builder(cordova.getActivity());
+                AlertDialog.Builder builder = new AlertDialog.Builder(cordova.getActivity(), AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
                 
                 // Set dialog properties
                 builder.setTitle(title);

--- a/www/ListPicker.js
+++ b/www/ListPicker.js
@@ -15,7 +15,7 @@ ListPicker.prototype.showPicker = function(options, callback, error_callback) {
     
     var config = {
         title: options.title || ' ',
-        selectedValue: options.selectedValue || '',
+        selectedValue: typeof(options.selectedValue) !== 'undefined' ? options.selectedValue : '',
         items: options.items || {},
         style: options.style || 'default',
         doneButtonLabel: options.doneButtonLabel || 'Done',


### PR DESCRIPTION
This brings the dialog theme in line with cordova-plugin-dialogs and adresses #17 In addition, the second keeps the plugin from ignoring selectedValue if it is falsy :smirk: 